### PR TITLE
fix: cast param in like as text

### DIFF
--- a/app/hooks/handle_search_query.ts
+++ b/app/hooks/handle_search_query.ts
@@ -16,7 +16,7 @@ export const handleSearchQuery = () =>
       } else {
         // number and boolean filters does not work with whereLike
         if (Number.isNaN(Number(value)) && !['true', 'false'].includes(value)) {
-          query.whereLike(param, value)
+          query.whereRaw(`cast(${param} as text) ILIKE '${value}'`)
         } else {
           query.where(param, value)
         }


### PR DESCRIPTION
It turned out that PostgreSQL enum is not counted as text in queries, so we needed to cast all like totext. Also like this is used in search queries I've changed like to case insensitive ilike.